### PR TITLE
Reset animation tick when idle to allow restart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,10 @@ export default class PositionObserver {
    */
   private _runCallback = () => {
     /* istanbul ignore if @preserve - a guard must be set */
-    if (!this.entries.size) return;
+    if (!this.entries.size) {
+      this._tick = 0;
+      return
+    };
     const { clientWidth, clientHeight } = this._root;
 
     const queue = new Promise<PositionObserverEntry[]>((resolve) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,6 +42,64 @@ describe("Offcanvas Class Tests", () => {
       );
     }
   });
+  
+  it("Should be able to observe elements again after unobserving all elements", async () => {
+    await page.viewport(400, 400);
+    const markup = getMarkup();
+    wrapper.append(markup);
+    await vi.waitFor(() => markup.querySelector('[data-test="tooltip"]'), 200);
+
+    const element = markup.querySelector<HTMLElement>('[data-test="tooltip"]')!;
+    const container = markup.ownerDocument.documentElement!;
+    const win = container.ownerDocument!.defaultView!;
+    
+    let callbackCount = 0;
+    const observer = new PositionObserver(() => {
+      callbackCount++;
+    }, { root: container });
+    observer.observe(element);
+
+    // First observation cycle - trigger position change to ensure callback
+    await vi.waitFor(() => {
+      expect(observer.entries.size).to.equal(1);
+    }, 100);
+    
+    // Trigger a position change to ensure callback is called
+    win.scrollTo({ top: 10, behavior: 'instant' });
+    await vi.waitFor(() => {
+      expect(callbackCount).to.be.greaterThan(0); // Callback should be called
+    }, 150);
+
+    // Unobserve all elements
+    observer.unobserve(element);
+    await vi.waitFor(() => {
+      expect(observer.entries.size).to.equal(0);
+    }, 50);
+
+    // Reset counter and scroll position for second test
+    callbackCount = 0;
+    win.scrollTo({ top: 0, behavior: 'instant' });
+    await new Promise(res => setTimeout(res, 50));
+
+    // Second observation cycle - re-observe the same element
+    observer.observe(element);
+    await vi.waitFor(() => {
+      expect(observer.entries.size).to.equal(1);
+    }, 100);
+    
+    // Trigger another position change to test if callback works
+    win.scrollTo({ top: 20, behavior: 'instant' });
+    await vi.waitFor(() => {
+      expect(callbackCount).to.be.greaterThan(0);
+    }, 150);
+
+    // Cleanup
+    win.scrollTo({ top: 0, behavior: 'instant' });
+    observer.disconnect();
+    await vi.waitFor(() => {
+      expect(observer.entries.size).to.equal(0);
+    }, 50);
+  });
 
   it("Init with target element", async () => {
     await page.viewport(400, 400);


### PR DESCRIPTION
I had a problem in my [project](https://github.com/spaansba/ForesightJS) where when I unobserve all elements and then observing an element again that it is not calling the callback. I think I figured out the reason for this happening. 

## The cause: 

1. On  `_runCallback`, if there are no elements  `if (!this.entries.size) return` will be hit
2. When you observe another element `if (!this._tick) this._tick = requestAnimationFrame(this._runCallback)` decides if we will need to request another animation frame.
3. However since `this._tick` is not reset on disconnecting the `_runCallback` it will never run again.

## Proposed solution:
Reset `this_tick` when there are no elements
```TS
if (!this.entries.size) {
  this._tick = 0
  return
}
````
